### PR TITLE
Add detailed DMXControl cue guides

### DIFF
--- a/show/README.md
+++ b/show/README.md
@@ -6,4 +6,4 @@ This folder contains documentation for running the lighting show.
 * `SHOW.md` gives a quick overview of lighting behavior in each scenario.
 * `VU_Triggers.md` explains how the show starts and ends automatically based on VU levels.
 * Individual scenario files (`Intermission.md`, `Slow_Pace.md`, etc.) describe every scene in detail.
-* Configuration guides for DMXControl 3.3.0 are located in the `instructions/` subfolder.
+* Configuration guides for DMXControl 3.3.0 are located in the `instructions/` subfolder. See `instructions/README.md` for detailed setup of the Audio Analyzer plugin.

--- a/show/instructions/Applause.md
+++ b/show/instructions/Applause.md
@@ -1,9 +1,21 @@
 # Configuring Applause
 
-1. Create a cue that fires automatically when VU levels drop at the end of a song.
-2. Blackout the Stage Lights, then let them strobe brightly in sync with the applause.
-3. Program a subtle shimmer on the Karaoke Corner fixtures using a fast sine wave effect.
-4. Set Music Lights to strobe at peak VU levels; PixieWash should spin wildly toward the audience for a few seconds.
-5. Trigger a single short burst of smoke as the lights reach their maximum.
-6. After roughly 10 seconds, fade into the **Intermission** cue.
-7. Save these settings as **Applause**.
+Use these steps to build a dynamic applause scene that plays whenever the
+Audio Analyzer detects the song ending.
+
+1. In **Show Editor**, create a new cue named **Applause** and place it after
+   **Slow Pace** in the cue list.
+2. Right‑click the **Audio Analyzer** node and choose **Add Trigger**. Set the
+   condition to **Low VU for 10 s** and select **Activate cue “Applause”** as the
+   action.
+3. In the cue, blackout the **Stage** group and add a **strobe** effect that
+   runs for about two seconds at 20 Hz.
+4. Select the **Karaoke Corner** group and apply a fast **sine wave** color
+   effect to create shimmering pulses.
+5. Set **Music Lights** to strobe when the trigger fires. Add a 360° spin macro
+   to the **PixieWash** moving head so it sweeps across the audience.
+6. Insert a short smoke burst in the timeline to coincide with the light peak.
+7. Add an **AutoLink** so that after 10 seconds the playback transitions back to
+   the **Intermission** cue.
+8. Save the cue and test by playing a song and letting the audio level fall to
+   ensure the trigger activates correctly.

--- a/show/instructions/High_Pace.md
+++ b/show/instructions/High_Pace.md
@@ -1,12 +1,20 @@
 # Configuring High Pace
 
-1. Duplicate the **Medium Pace** cue to build a new cue.
-2. Turn Stage Lights intensity down to near zero so they remain in the background,
-   but spike them slightly when the PixieWash swings toward the audience.
-3. Change the Karaoke Corner color chase to rapid flashes (under 1 second per step) in vivid greens and blues.
-4. Set the Music Lights to strobe when VU levels exceed a threshold and use movement macros to keep motion fast and energetic.
-5. Adjust the PixieWash to start on the artist and sweep toward the audience
-   after roughly 150 seconds. Couple this sweep with the brief Stage Light spike
-   for dramatic emphasis.
-6. Program the smoke machine for strong bursts every 45 seconds.
-7. Save this as **High Pace** in the cue list.
+This cue brings maximum energy with aggressive color changes and heavy strobing.
+
+1. Duplicate the **Medium Pace** cue and rename the copy **High Pace**.
+2. In the **Stage** group, lower dimmer values close to zero so other fixtures
+   dominate. Add a short **flash** step that bumps intensity when the
+   **PixieWash** sweeps toward the audience.
+3. For **Karaoke Corner**, increase the chase rate to less than one second per
+   step and alternate vivid greens and blues.
+4. Edit the **Audio Analyzer** triggers so that high VU levels cause the
+   **LumiPar 12UQPro** fixtures to strobe rapidly. Apply movement macros to keep
+   them spinning between beats.
+5. Program the **PixieWash** to begin on the artist, then perform a fast sweep
+   toward the crowd after about 150 s, syncing the Stage Light flash with this
+   move.
+6. Schedule the **Smoke Machine** for strong bursts every 45 s to emphasize
+   musical climaxes.
+7. Preview the cue and fine‑tune any timing offsets before saving it in the cue
+   list.

--- a/show/instructions/Intermission.md
+++ b/show/instructions/Intermission.md
@@ -1,14 +1,20 @@
 # Configuring Intermission
 
-1. Open DMXControl 3.3.0 and load your project.
-2. Assign the Stage Lights (LumiPar 12UAW5 #1–3) to a group called `Stage`.
-3. Create a static scene with warm white dimmer values around 40% for the `Stage` group.
-4. Set Karaoke Corner fixtures to a soft peach color using the color picker.
-5. Ensure all music lights and the smoke machine channels are set to 0 (off).
-6. Store this configuration as a cue named **Intermission** in the cue list.
-7. Link this cue after **Applause** so the show returns to a calm state
-   automatically.
-8. Create an automation rule that starts the show when the
-   average VU level during the last 10 seconds rises above your
-   start threshold. Likewise, return to **Intermission** when that
-   10-second average falls below the end threshold.
+This cue provides a neutral lighting state between songs. Follow these steps to
+set it up.
+
+1. Launch DMXControl 3.3.0 and open your show project.
+2. In **Device Control**, assign the Stage Lights (LumiPar 12UAW5 #1–3) to a
+   group called `Stage` if it is not already created.
+3. Create a new cue and name it **Intermission**.
+4. For the `Stage` group, set a static warm white around 40 % intensity.
+5. Select the **Karaoke Corner** fixtures and pick a soft peach hue in the color
+   picker.
+6. Ensure all **Music Lights** and the **Smoke Machine** channels are set to 0.
+7. Click **Store** to save this cue in the cue list.
+8. Drag **Intermission** to the top of the cue stack so it plays whenever the
+   show starts.
+9. In the **Audio Analyzer**, configure a trigger that activates this cue when
+   the average VU level over the last 10 s falls below your end threshold.
+10. Likewise create a separate trigger that moves to **Slow Pace** when the VU
+    level rises above your start threshold.

--- a/show/instructions/Medium_Pace.md
+++ b/show/instructions/Medium_Pace.md
@@ -1,11 +1,18 @@
 # Configuring Medium Pace
 
-1. Duplicate the **Slow Pace** cue to create a new cue.
-2. Reduce Stage Lights intensity to 30% so other zones stand out. Momentarily
-   raise them about 10% when the PixieWash flips to the audience.
-3. Increase the color-change speed of the Karaoke Corner chase to around 5 seconds per step.
-4. In the VU plugin, map higher levels to brighter outputs on the Music Lights and use the color wheel to alternate between reds and yellows.
-5. Program the PixieWash to start on the performer and swing toward the audience
-   after roughly 150 seconds, linking the brief Stage Light bump to that swing.
-6. Trigger the smoke machine for short bursts every 25 seconds.
-7. Save these settings as **Medium Pace**.
+The medium pace cue increases activity while still leaving room to build toward
+the finale.
+
+1. Duplicate the **Slow Pace** cue and rename it **Medium Pace**.
+2. Lower the Stage Lights intensity to about 30 %, adding a small 10 %
+   brightness bump when the **PixieWash** turns toward the audience.
+3. Edit the **Karaoke Corner** chase to step every five seconds, giving the
+   impression of rising tempo.
+4. Configure the **Audio Analyzer** so that higher VU levels make the
+   **LumiPar 12UQPro** fixtures brighter and alternate between red and yellow on
+   the color wheel.
+5. Set a movement track for the **PixieWash** that begins on the performer and
+   pans to the audience after roughly 150 s, synchronized with the Stage Light
+   bump.
+6. Schedule the **Smoke Machine** for short bursts every 25 s.
+7. After verifying timing and brightness, store the cue in the list.

--- a/show/instructions/README.md
+++ b/show/instructions/README.md
@@ -1,0 +1,53 @@
+# DMXControl 3.3.0 Configuration Guide
+
+This document explains how to set up DMXControl 3.3.0 with the **Audio Analyzer** plugin. The Audio Analyzer allows cues and effects to react to audio input (such as music or applause) in real time.
+
+## 1. Launch DMXControl
+
+1. Install DMXControl 3.3.0 if not already installed.
+2. Start DMXControl and create or open your project.
+
+## 2. Enable the Audio Analyzer Plugin
+
+1. Go to **Settings → Plugin Manager**.
+2. Locate **Audio Analyzer** in the list and check the **Enable** box.
+3. Restart DMXControl when prompted so the plugin loads correctly.
+
+## 3. Configure the Audio Analyzer
+
+1. After DMXControl restarts, open **Show Editor** and add the **Audio Analyzer** to a free layer.
+2. Double-click the newly created Audio Analyzer node to open its properties.
+3. In the **Input Source** field, choose the audio device (e.g., your sound card or loopback driver).
+4. Adjust the **FFT size** and **smoothing** settings as needed for your system.
+5. Click **OK** to save.
+
+## 4. Creating Triggers
+
+1. Right-click the Audio Analyzer node and select **Add Trigger**.
+2. Choose the frequency band or VU level that should start the trigger.
+3. Pick an **action** such as firing a cue, activating a light effect or increasing intensity.
+4. Repeat for as many triggers as required for your show.
+
+## 5. Example: Linking to a Cue
+
+1. Create a cue called **Applause** (see `Applause.md` for details).
+2. Add a trigger with **High VU** as the condition and set the action to **Activate cue “Applause”**.
+3. Set **Hold time** to keep the cue active for about 10 seconds.
+4. Optionally, add another trigger using **Low VU** to return to the **Intermission** cue.
+
+## 6. Saving Your Setup
+
+1. Press **Ctrl+S** to save the project file.
+2. Test the audio detection by playing music and watching the DMX output respond.
+3. Adjust trigger thresholds if the lights fire too early or too late.
+
+Detailed step-by-step guides for creating each cue are available in these files:
+
+* `Intermission.md`
+* `Slow_Pace.md`
+* `Medium_Pace.md`
+* `High_Pace.md`
+* `Applause.md`
+
+They explain exactly which fixtures to adjust and how to link each cue to Audio
+Analyzer triggers.

--- a/show/instructions/Slow_Pace.md
+++ b/show/instructions/Slow_Pace.md
@@ -1,13 +1,18 @@
 # Configuring Slow Pace
 
-1. Start from the **Intermission** cue as a base.
-2. For Stage Lights, keep intensity stable around 50% with no color changes; at
-   the 150‑second mark when the PixieWash sweeps to the crowd, raise them to
-   about 60% briefly.
-3. Program Karaoke Corner fixtures with a slow color chase (10–15s fade time) cycling through reds and ambers.
-4. Set Music Lights to respond to microphone input via the VU plugin; enable smooth fades linked to audio levels.
-5. Add a movement track for the PixieWash that begins on the artist and pans
-   toward the audience after 150 seconds, linking the brightness bump from the
-   Stage Lights to that motion.
-6. Program the smoke machine to trigger short bursts every 15 seconds at low intensity.
-7. Save this setup as **Slow Pace** in your cue list.
+This cue gently engages the audience while still keeping a calm atmosphere.
+
+1. Start from the **Intermission** cue and duplicate it as **Slow Pace**.
+2. Keep the **Stage** group intensity around 50 %. Insert a brief raise to
+   60 % at the 150 s mark when the **PixieWash** pans to the crowd.
+3. Program the **Karaoke Corner** fixtures with a slow color chase using 10–15 s
+   fade times cycling through reds and ambers.
+4. Set the **Audio Analyzer** to drive the **Music Lights** with smooth fades so
+   they brighten as the VU increases.
+5. Create a movement track for the **PixieWash** beginning on the performer and
+   slowly panning toward the audience after 150 s. Link the Stage Light bump to
+   this motion.
+6. Program the **Smoke Machine** to trigger short bursts every 15 s at low
+   intensity.
+7. Store the cue, then test by gradually raising and lowering music volume to
+   see how the lights react.


### PR DESCRIPTION
## Summary
- expand Audio Analyzer instructions link list
- add step-by-step instructions for Applause, Intermission, Slow Pace, Medium Pace, and High Pace cues

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6866d5db887c8329bad6b4e7c56f3702